### PR TITLE
Added API Token functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ First off, open https://api.cloudflare.com/ to see all the available endpoints
   require 'rubyflare'
   
   connection = Rubyflare.connect_with('bear@dog.com', 'supersecretapikey')
+
+  # OR connect with API Token
+  connection = Rubyflare.connect_with_token('API_TOKEN')
 ```
 
 #### GET your user account details

--- a/lib/rubyflare.rb
+++ b/lib/rubyflare.rb
@@ -15,6 +15,11 @@ module Rubyflare
   end
 
   def self.connect_with(email, api_key)
-    Rubyflare::Connect.new(email, api_key)
+    # Rubyflare::Connect.new(email, api_key)
+    Rubyflare::Connect.new(email: email, api_key: api_key)
+  end
+
+  def self.connect_with_token(api_token)
+    Rubyflare::Connect.new(api_token: api_token)
   end
 end

--- a/lib/rubyflare.rb
+++ b/lib/rubyflare.rb
@@ -15,7 +15,6 @@ module Rubyflare
   end
 
   def self.connect_with(email, api_key)
-    # Rubyflare::Connect.new(email, api_key)
     Rubyflare::Connect.new(email: email, api_key: api_key)
   end
 

--- a/lib/rubyflare/connect.rb
+++ b/lib/rubyflare/connect.rb
@@ -5,7 +5,6 @@ module Rubyflare
 
     API_URL = "https://api.cloudflare.com/client/v4/"
 
-    # def initialize(email, api_key)
     def initialize(**options)
       @api_token = options[:api_token]
       @email = options[:email]

--- a/lib/rubyflare/connect.rb
+++ b/lib/rubyflare/connect.rb
@@ -7,14 +7,9 @@ module Rubyflare
 
     # def initialize(email, api_key)
     def initialize(**options)
-      if options.length == 1
-        # We are using an API token
-        @api_token = options[:api_token]
-      elsif options.length == 2
-        # Usual email and API connection
-        @email = options[:email]
-        @api_key = options[:api_key]
-      end
+      @api_token = options[:api_token]
+      @email = options[:email]
+      @api_key = options[:api_key]
 
     end
     
@@ -37,5 +32,4 @@ module Rubyflare
     end
   end
 end
-
 

--- a/lib/rubyflare/connect.rb
+++ b/lib/rubyflare/connect.rb
@@ -5,17 +5,30 @@ module Rubyflare
 
     API_URL = "https://api.cloudflare.com/client/v4/"
 
-    def initialize(email, api_key)
-      @email = email
-      @api_key = api_key
+    # def initialize(email, api_key)
+    def initialize(**options)
+      if options.length == 1
+        # We are using an API token
+        @api_token = options[:api_token]
+      elsif options.length == 2
+        # Usual email and API connection
+        @email = options[:email]
+        @api_key = options[:api_key]
+      end
+
     end
     
     %i(get post put patch delete).each do |method_name|
       define_method(method_name) do |endpoint, options = {}|
         options = options.to_json unless method_name == :get
         response = Curl.send(method_name, API_URL + endpoint, options) do |http|
-          http.headers['X-Auth-Email'] = @email
-          http.headers['X-Auth-Key'] = @api_key
+          # Send the Bearer request if using an API Token
+          unless @api_token.nil?
+            http.headers['Authorization'] = "Bearer " + @api_token
+          else
+            http.headers['X-Auth-Email'] = @email
+            http.headers['X-Auth-Key'] = @api_key
+          end
           http.headers['Content-Type'] = 'application/json'
           http.headers['User-Agent'] = "Rubyflare/#{Rubyflare::VERSION}"
         end

--- a/lib/rubyflare/version.rb
+++ b/lib/rubyflare/version.rb
@@ -1,3 +1,3 @@
 module Rubyflare
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/rubyflare.gemspec
+++ b/rubyflare.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0'
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 11.3"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "webmock", "~> 2.1"


### PR DESCRIPTION
I've added Cloudflare API Token functionality with the connect_with_token(api_token) method. The connect function now uses a hash to determine if Rubyflare should use an API token or the traditional email / API key combination. This change retains backwards compatibility with previous versions of Rubyflare.

It is possible to have the connect_with method used for both email / key and token but I figured that would add some confusion so decided to split the functions.